### PR TITLE
Additional Text about Subject Name

### DIFF
--- a/draft-ietf-uta-tls13-iot-profile.md
+++ b/draft-ietf-uta-tls13-iot-profile.md
@@ -493,7 +493,7 @@ issuer field in all certificates issued by the subject CA."
 
 Root CA certificates MUST have a non-empty subjectName.
 
-The subjectName MUST contain the commonName, the organizationName, and the countryName attribute and MAY contain an organizationalUnitName attribute.
+The subject field MUST contain the commonName, the organizationName, and the countryName attribute and MAY contain an organizationalUnitName attribute.
 
 ### Authority Key Identifier
 

--- a/draft-ietf-uta-tls13-iot-profile.md
+++ b/draft-ietf-uta-tls13-iot-profile.md
@@ -491,7 +491,7 @@ RFC 5280 adds "If the subject is a CA then the subject field MUST be
 populated with a non-empty distinguished name matching the contents of the
 issuer field in all certificates issued by the subject CA."
 
-Root CA certificates MUST have a non-empty subjectName.
+Root CA certificates MUST have a non-empty subject field.
 
 The subject field MUST contain the commonName, the organizationName, and the countryName attribute and MAY contain an organizationalUnitName attribute.
 

--- a/draft-ietf-uta-tls13-iot-profile.md
+++ b/draft-ietf-uta-tls13-iot-profile.md
@@ -481,17 +481,19 @@ MUST NOT be marked critical.
 
 This section outlines the requirements for root CA certificates.
 
-## subjectName
+## Subject
 
-{{!RFC5280}} defines the subjectName field as follows: "The subject field identifies
-the entity associated with the public key stored in the subject public key
-field." RFC 5280 adds "If the subject is a CA then the subject field MUST be
+Section 4.1.2.6 of {{!RFC5280}} defines the subject field as follows: "The subject field identifies
+the entity associated with the public key stored in the subject public key field. The subject name
+MAY be carried in the subject field and/or the subjectAltName extension."
+
+RFC 5280 adds "If the subject is a CA then the subject field MUST be
 populated with a non-empty distinguished name matching the contents of the
 issuer field in all certificates issued by the subject CA."
 
 Root CA certificates MUST have a non-empty subjectName.
 
-The subjectName MUST contain the commonName, the  organizationName, and the countryName attribute and MAY contain an organizationalUnitName attribute.
+The subjectName MUST contain the commonName, the organizationName, and the countryName attribute and MAY contain an organizationalUnitName attribute.
 
 ### Authority Key Identifier
 


### PR DESCRIPTION
The problem is that RFC 5280 says that the subject name is contained in the subject field and/or the subjectAltName extension. The ASN.1 does not seem to support the case that the subject field is optional